### PR TITLE
Fix the slider name from 'slider_left' to 'slider_right'

### DIFF
--- a/openarm_grip_description/urdf/openarm_grip.urdf
+++ b/openarm_grip_description/urdf/openarm_grip.urdf
@@ -422,7 +422,7 @@
     <axis xyz="-1.0 0.0 -0.0"/>
     <limit acceleration="0.5" effort="100" lower="-0.0455" upper="0.0" velocity="1.0"/>
   </joint>
-  <joint name="slider_left" type="prismatic">
+  <joint name="slider_right" type="prismatic">
     <origin rpy="0 0 0" xyz="0.0775 -0.121655 0.012086"/>
     <parent link="grip_attach_1"/>
     <child link="right_jaw_1"/>

--- a/openarm_grip_description/urdf/openarm_grip.xacro
+++ b/openarm_grip_description/urdf/openarm_grip.xacro
@@ -285,7 +285,7 @@
   <limit upper="0.0" lower="-0.0455" effort="100" velocity="1.0" acceleration="0.5"/>
 </joint>
 
-<joint name="slider_left" type="prismatic">
+<joint name="slider_right" type="prismatic">
   <origin xyz="0.0775 -0.121655 0.012086" rpy="0 0 0"/>
   <parent link="grip_attach_1"/>
   <child link="right_jaw_1"/>


### PR DESCRIPTION
When I tried to load the URDF file on MuJoCo, it failed with
the following error message:

    Duplicated slider name "slider_left"

It turned out that the issue was the right slider being wrongly
tagged as 'slider_left' (not 'slider_right'). Fix it thusly.