### PR TITLE
clang-format: add pre-commit and CI lint workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: Google

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,5 +28,4 @@ jobs:
           restore-keys: pre-commit-
       - name: Run
         run: |
-          set -o pipefail
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install pre-commit
+      - name: Install
         run: |
           python -m pip install pre-commit
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Run pre-commit
+      - name: Run
         run: |
           set -o pipefail
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
   pull_request:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-
       - name: Run
         run: |
           set -o pipefail

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   pre-commit:
     name: pre-commit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+on:
+  push:
+  pull_request:
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: |
+          set -o pipefail
+          pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: "v20.1.4"
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
We introduce pre-commit hook with clang-format to
enforce a unified code style across the project,
reducing style discussions and speeding up cod
reviews.

ref: https://pre-commit.com/