### PR TITLE
fix: move xml-model declaration above license header

### DIFF
--- a/openarm/package.xml
+++ b/openarm/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm</name>
   <version>0.3.0</version>

--- a/openarm_bimanual_bringup/package.xml
+++ b/openarm_bimanual_bringup/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_bimanual_bringup</name>
   <version>0.3.0</version>

--- a/openarm_bimanual_description/package.xml
+++ b/openarm_bimanual_description/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_bimanual_description</name>
   <version>0.3.0</version>

--- a/openarm_bimanual_moveit_config/package.xml
+++ b/openarm_bimanual_moveit_config/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_bimanual_moveit_config</name>
   <version>0.3.0</version>

--- a/openarm_bringup/package.xml
+++ b/openarm_bringup/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_bringup</name>
   <version>0.3.0</version>

--- a/openarm_description/package.xml
+++ b/openarm_description/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_description</name>
   <version>0.3.0</version>

--- a/openarm_hardware/package.xml
+++ b/openarm_hardware/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_hardware</name>
   <version>0.3.0</version>

--- a/openarm_moveit_config/package.xml
+++ b/openarm_moveit_config/package.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 　Copyright 2025 Reazon Holdings, Inc.
 
@@ -14,7 +15,6 @@
 　See the License for the specific language governing permissions and
 　limitations under the License.
 -->
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>openarm_moveit_config</name>
   <version>0.3.0</version>


### PR DESCRIPTION
## Problem

When we launch openarm_bringup, the following error are raised.

```console
$ ros2 launch openarm_bringup openarm.launch.py
[INFO] [launch]: All log files can be found below /home/otegami/.ros/log/2025-05-23-15-07-52-834283-otegami-2239551
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [ros2_control_node-1]: process started with pid [2239568]
[INFO] [robot_state_publisher-2]: process started with pid [2239569]
[INFO] [rviz2-3]: process started with pid [2239570]
[robot_state_publisher-2] [INFO] [1747984073.330768599] [robot_state_publisher]: Robot initialized
[ros2_control_node-1] [INFO] [1747984073.346291338] [controller_manager]: Using Steady (Monotonic) clock for triggering controller manager cycles.
[ros2_control_node-1] [ERROR] [1747984073.346957366] [pluginlib.ClassLoader]: Could not find a root element for package manifest at /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/package.xml.
[ros2_control_node-1] [ERROR] [1747984073.347001329] [pluginlib.ClassLoader]: Could not find package manifest (neither package.xml or deprecated manifest.xml) at same directory level as the plugin XML file /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/openarm_hardware.xml. Plugins will likely not be exported properly.
[ros2_control_node-1] )
[ros2_control_node-1] [ERROR] [1747984073.347237704] [pluginlib.ClassLoader]: Could not find a root element for package manifest at /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/package.xml.
[ros2_control_node-1] [ERROR] [1747984073.347246277] [pluginlib.ClassLoader]: Could not find package manifest (neither package.xml or deprecated manifest.xml) at same directory level as the plugin XML file /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/openarm_hardware.xml. Plugins will likely not be exported properly.
[ros2_control_node-1] )
[ros2_control_node-1] [ERROR] [1747984073.347465709] [pluginlib.ClassLoader]: Could not find a root element for package manifest at /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/package.xml.
[ros2_control_node-1] [ERROR] [1747984073.347471103] [pluginlib.ClassLoader]: Could not find package manifest (neither package.xml or deprecated manifest.xml) at same directory level as the plugin XML file /home/otegami/work/cpp/ros2_ws/install/openarm_hardware/share/openarm_hardware/openarm_hardware.xml. Plugins will likely not be exported properly.
```

## Cause

when the license comments appeared before the
xml-model instruction, it happedned.

## Solution

This PR changes places the xml-model declaration
immediately after the XML prolog and ahead of the
license block to resolve the issue.