### PR TITLE
openarm_hardware: add ros2_control_test_assets as a test dependency

### DIFF
--- a/openarm_hardware/CMakeLists.txt
+++ b/openarm_hardware/CMakeLists.txt
@@ -63,6 +63,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(hardware_interface REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
 
   ament_add_gmock(test_openarm_hardware
     test/test_openarm_hardware.cpp
@@ -72,6 +73,7 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_openarm_hardware
     hardware_interface
+    ros2_control_test_assets
   )
 
   set(ament_cmake_copyright_FOUND TRUE)

--- a/openarm_hardware/package.xml
+++ b/openarm_hardware/package.xml
@@ -30,6 +30,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Problem

When building openarm_ros2, the hardware interface tests fail because the components_urdfs.hpp header from ros2_control_test_assets cannot be found as
follows.

```console
$ colcon build
...
/home/otegami/work/cpp/ros2_ws/src/openarm_ros2/openarm_hardware/test/test_openarm_hardware.cpp:21:10: fatal error: ros2_control_test_assets/components_urdfs.hpp: No such file or directory
   21 | #include "ros2_control_test_assets/components_urdfs.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/test_openarm_hardware.dir/build.make:79: CMakeFiles/test_openarm_hardware.dir/test/test_openarm_hardware.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:237: CMakeFiles/test_openarm_hardware.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< openarm_hardware [14.9s, exited with code 2]

Summary: 6 packages finished [15.1s]
  1 package failed: openarm_hardware
  5 packages had stderr output: openarm_bimanual_bringup openarm_bimanual_description openarm_bringup openarm_description openarm_hardware
  1 package not processed
```

## Cause

Although ros2_control_test_assets was installed, it wasn’t declared as a dependency of the GMock test
target.

## Solution

Add ros2_control_test_assets as a test dependency in both the CMakeLists.txt and in the package.xml,
ensuring the test can locate its headers.