### PR TITLE
fix: malfunctioning launch script

### DIFF
--- a/openarm_bringup/launch/openarm.launch.py
+++ b/openarm_bringup/launch/openarm.launch.py
@@ -131,7 +131,7 @@ def generate_launch_description():
         [FindPackageShare(runtime_config_package), "config", controllers_file]
     )
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare(description_package), "rviz", "openarm.rviz"]
+        [FindPackageShare(description_package), "rviz", "robot_description.rviz"]
     )
 
     control_node = Node(

--- a/openarm_description/urdf/openarm.ros2_control.xacro
+++ b/openarm_description/urdf/openarm.ros2_control.xacro
@@ -15,16 +15,20 @@
 　limitations under the License.
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-    <xacro:macro name="openarm_ros2_control" params="name initial_positions_file prefix:='' can_device='can0'">
+    <xacro:macro name="openarm_ros2_control" params="name initial_positions_file prefix:='' can_device='can0' use_mock_hardware:=false mock_sensor_commands:=false">
         <xacro:property name="initial_positions" value="${xacro.load_yaml(initial_positions_file)['initial_positions']}"/>
 
         <ros2_control name="${prefix}${name}" type="system">
             <hardware>
-                <!-- By default, set up controllers for simulation. This won't work on real hardware -->
-                <!-- <plugin>mock_components/GenericSystem</plugin> -->
-                <plugin>openarm_hardware/OpenArmHW</plugin>
-                <param name="prefix">${prefix}</param>
-                <param name="can_device">${can_device}</param>
+                <xacro:if value="${use_mock_hardware}">
+                    <plugin>mock_components/GenericSystem</plugin>
+                    <param name="mock_sensor_commands">${mock_sensor_commands}</param>
+                </xacro:if>
+                <xacro:unless value="${use_mock_hardware}">
+                    <plugin>openarm_hardware/OpenArmHW</plugin>
+                    <param name="prefix">${prefix}</param>
+                    <param name="can_device">${can_device}</param>
+                </xacro:unless>
             </hardware>
             <joint name="${prefix}rev1">
                 <command_interface name="position"/>

--- a/openarm_description/urdf/openarm.urdf.xacro
+++ b/openarm_description/urdf/openarm.urdf.xacro
@@ -15,7 +15,11 @@
 　limitations under the License.
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="openarm">
+    <xacro:arg name="prefix" default="" />
+    <xacro:arg name="use_mock_hardware" default="false" />
+    <xacro:arg name="mock_sensor_commands" default="false" />
+    
     <xacro:include filename="openarm.xacro"/>
-    <xacro:openarm/>
+    <xacro:openarm prefix="$(arg prefix)" use_mock_hardware="$(arg use_mock_hardware)" mock_sensor_commands="$(arg mock_sensor_commands)"/>
     <xacro:include filename="$(find openarm_description)/urdf/openarm_sensors.xacro"/>
 </robot>

--- a/openarm_description/urdf/openarm.xacro
+++ b/openarm_description/urdf/openarm.xacro
@@ -23,7 +23,7 @@
         <color rgba="${50/255} ${50/255} ${50/255} 1.0"/>
     </material>
 
-    <xacro:macro name="openarm" params="side:='right' prefix:='' zero_pos='up' can_device='can0'">
+    <xacro:macro name="openarm" params="side:='right' prefix:='' zero_pos='up' can_device='can0' use_mock_hardware:=false mock_sensor_commands:=false">
         <!-- side right, left -->
         <!-- recommended prefixes left_, right_, etc. -->
         <!-- zero_pos up, arm -->
@@ -34,7 +34,7 @@
 
         <xacro:include filename="$(find openarm_description)/urdf/openarm.ros2_control.xacro" />
         <xacro:arg name="initial_positions_file" default="$(find openarm_description)/config/initial_positions.yaml" />
-        <xacro:openarm_ros2_control name="OpenArmHW" prefix="${prefix}" initial_positions_file="$(arg initial_positions_file)" can_device="${can_device}"/>
+        <xacro:openarm_ros2_control name="OpenArmHW" prefix="${prefix}" initial_positions_file="$(arg initial_positions_file)" can_device="${can_device}" use_mock_hardware="${use_mock_hardware}" mock_sensor_commands="${mock_sensor_commands}"/>
 
         <link name="${prefix}dummy_link"/>
 


### PR DESCRIPTION
## Issue
- **openarm_bringup/openarm.launch.py** was launching rviz2 with an incorrect configuration file.
- The same launch script is intended to execute xacro with a configurable prefix and support mock hardware. However, these features were not functioning as the required arguments and plugin initialization were missing from the xacro files.

## Fix
- Updated the rviz configuration path to the correct file.
- Added the necessary arguments and plugin setup to the relevant xacro files to enable prefix configuration and mock hardware support.