### PR TITLE
lint: add autopep8 to pre-commit hook for Python formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,7 @@ repos:
     rev: "v20.1.4"
     hooks:
       - id: clang-format
+  - repo: https://github.com/hhatto/autopep8
+    rev: "v2.3.2"
+    hooks:
+     - id: autopep8

--- a/openarm_bimanual_bringup/launch/depth_camera.launch.py
+++ b/openarm_bimanual_bringup/launch/depth_camera.launch.py
@@ -17,6 +17,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
 
+
 def generate_launch_description():
     realsense_share_dir = FindPackageShare("realsense2_camera")
     rs_launch_path = [realsense_share_dir, "/launch/rs_launch.py"]

--- a/openarm_bimanual_bringup/launch/start_teleop.launch.py
+++ b/openarm_bimanual_bringup/launch/start_teleop.launch.py
@@ -37,7 +37,8 @@ def generate_launch_description():
     )
 
     use_sim_time = LaunchConfiguration("use_sim_time")
-    use_sim_time_launch_arg = DeclareLaunchArgument(name="use_sim_time", default_value="false")
+    use_sim_time_launch_arg = DeclareLaunchArgument(
+        name="use_sim_time", default_value="false")
 
     robot_state_publisher_node = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -54,14 +55,16 @@ def generate_launch_description():
         launch_arguments=dict(use_sim_time=use_sim_time).items(),
     )
 
-    robot_description_content = Command(["xacro ", LaunchConfiguration("model")])
+    robot_description_content = Command(
+        ["xacro ", LaunchConfiguration("model")])
 
     robot_description_param = {
         "robot_description": ParameterValue(robot_description_content, value_type=str)
     }
 
     controller_params = PathJoinSubstitution(
-        [FindPackageShare(package="openarm_bimanual_bringup"), "config", "controllers.yaml"]
+        [FindPackageShare(package="openarm_bimanual_bringup"),
+         "config", "controllers.yaml"]
     )
 
     controller_manager = Node(
@@ -70,7 +73,8 @@ def generate_launch_description():
         parameters=[controller_params, robot_description_param],
     )
 
-    delayed_controller_manager = TimerAction(period=3.0, actions=[controller_manager])
+    delayed_controller_manager = TimerAction(
+        period=3.0, actions=[controller_manager])
 
     joint_broadcaster_spawner = Node(
         package="controller_manager",

--- a/openarm_bimanual_description/launch/description.launch.py
+++ b/openarm_bimanual_description/launch/description.launch.py
@@ -32,7 +32,8 @@ def generate_launch_description():
     default_model_path = pkg_share / "urdf/openarm_bimanual.urdf.xacro"
 
     use_sim_time = LaunchConfiguration("use_sim_time")
-    use_sim_time_launch_arg = DeclareLaunchArgument("use_sim_time", default_value="true")
+    use_sim_time_launch_arg = DeclareLaunchArgument(
+        "use_sim_time", default_value="true")
 
     robot_state_publisher_node = launch_ros.actions.Node(
         package="robot_state_publisher",

--- a/openarm_bimanual_description/launch/display.launch.py
+++ b/openarm_bimanual_description/launch/display.launch.py
@@ -53,7 +53,8 @@ def generate_launch_description():
         package="joint_state_publisher",
         executable="joint_state_publisher",
         name="joint_state_publisher",
-        condition=launch.conditions.UnlessCondition(LaunchConfiguration("gui")),
+        condition=launch.conditions.UnlessCondition(
+            LaunchConfiguration("gui")),
         parameters=[
             {
                 "use_sim_time": use_sim_time,

--- a/openarm_bimanual_description/launch/gazebo.launch.py
+++ b/openarm_bimanual_description/launch/gazebo.launch.py
@@ -36,7 +36,8 @@ def generate_launch_description():
 
     # Make path to resources dir without last package_name fragment.
     path_to_share_dir_clipped = "".join(
-        get_package_share_directory(resources_package).rsplit("/" + resources_package, 1)
+        get_package_share_directory(resources_package).rsplit(
+            "/" + resources_package, 1)
     )
 
     # Gazebo hint for resources.
@@ -55,9 +56,11 @@ def generate_launch_description():
             os.environ["SDF_PATH"] = gz_sim_resource_path
 
     use_custom_world = LaunchConfiguration("use_custom_world")
-    use_custom_world_launch_arg = DeclareLaunchArgument("use_custom_world", default_value="true")
+    use_custom_world_launch_arg = DeclareLaunchArgument(
+        "use_custom_world", default_value="true")
     gazebo_world = LaunchConfiguration("gazebo_world")
-    gazebo_world_launch_arg = DeclareLaunchArgument("gazebo_world", default_value="empty.sdf")
+    gazebo_world_launch_arg = DeclareLaunchArgument(
+        "gazebo_world", default_value="empty.sdf")
 
     # prepare custom world
     world = os.getenv("GZ_SIM_WORLD", "empty")
@@ -100,7 +103,8 @@ def generate_launch_description():
     )
 
     use_sim_time = LaunchConfiguration("use_sim_time")
-    use_sim_time_launch_arg = DeclareLaunchArgument("use_sim_time", default_value="true")
+    use_sim_time_launch_arg = DeclareLaunchArgument(
+        "use_sim_time", default_value="true")
     use_rviz = LaunchConfiguration("use_rviz")
     use_rviz_arg = DeclareLaunchArgument("use_rviz", default_value="true")
 

--- a/openarm_bimanual_moveit_config/launch/demo.launch.py
+++ b/openarm_bimanual_moveit_config/launch/demo.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_demo_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_demo_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/move_group.launch.py
+++ b/openarm_bimanual_moveit_config/launch/move_group.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_move_group_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_move_group_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/moveit_rviz.launch.py
+++ b/openarm_bimanual_moveit_config/launch/moveit_rviz.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_moveit_rviz_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_moveit_rviz_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/rsp.launch.py
+++ b/openarm_bimanual_moveit_config/launch/rsp.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_rsp_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_rsp_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/setup_assistant.launch.py
+++ b/openarm_bimanual_moveit_config/launch/setup_assistant.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_setup_assistant_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_setup_assistant_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/spawn_controllers.launch.py
+++ b/openarm_bimanual_moveit_config/launch/spawn_controllers.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_spawn_controllers_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_spawn_controllers_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/static_virtual_joint_tfs.launch.py
+++ b/openarm_bimanual_moveit_config/launch/static_virtual_joint_tfs.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_static_virtual_joint_tfs_laun
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_static_virtual_joint_tfs_launch(moveit_config)

--- a/openarm_bimanual_moveit_config/launch/warehouse_db.launch.py
+++ b/openarm_bimanual_moveit_config/launch/warehouse_db.launch.py
@@ -17,5 +17,6 @@ from moveit_configs_utils.launches import generate_warehouse_db_launch
 
 
 def generate_launch_description():
-    moveit_config = MoveItConfigsBuilder("openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
+    moveit_config = MoveItConfigsBuilder(
+        "openarm_bimanual", package_name="openarm_bimanual_moveit_config").to_moveit_configs()
     return generate_warehouse_db_launch(moveit_config)

--- a/openarm_bringup/launch/openarm.launch.py
+++ b/openarm_bringup/launch/openarm.launch.py
@@ -89,7 +89,8 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "robot_controller",
             default_value="joint_trajectory_controller",
-            choices=["forward_position_controller", "joint_trajectory_controller"],
+            choices=["forward_position_controller",
+                     "joint_trajectory_controller"],
             description="Robot controller to start.",
         )
     )
@@ -110,7 +111,8 @@ def generate_launch_description():
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
             PathJoinSubstitution(
-                [FindPackageShare(description_package), "urdf", description_file]
+                [FindPackageShare(description_package),
+                 "urdf", description_file]
             ),
             " ",
             "prefix:=",
@@ -131,7 +133,8 @@ def generate_launch_description():
         [FindPackageShare(runtime_config_package), "config", controllers_file]
     )
     rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare(description_package), "rviz", "robot_description.rviz"]
+        [FindPackageShare(description_package), "rviz",
+         "robot_description.rviz"]
     )
 
     control_node = Node(
@@ -157,7 +160,8 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster",
+                   "--controller-manager", "/controller_manager"],
     )
 
     robot_controller_names = [robot_controller]
@@ -178,7 +182,8 @@ def generate_launch_description():
             Node(
                 package="controller_manager",
                 executable="spawner",
-                arguments=[controller, "-c", "/controller_manager", "--inactive"],
+                arguments=[controller, "-c",
+                           "/controller_manager", "--inactive"],
             )
         ]
 

--- a/openarm_bringup/launch/test_forward_position_controller.launch.py
+++ b/openarm_bringup/launch/test_forward_position_controller.launch.py
@@ -28,7 +28,8 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     position_goals = PathJoinSubstitution(
-        [FindPackageShare("openarm_bringup"), "config", "test_goal_publishers_config.yaml"]
+        [FindPackageShare("openarm_bringup"), "config",
+         "test_goal_publishers_config.yaml"]
     )
 
     return LaunchDescription(

--- a/openarm_bringup/launch/test_joint_trajectory_controller.launch.py
+++ b/openarm_bringup/launch/test_joint_trajectory_controller.launch.py
@@ -28,7 +28,8 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     position_goals = PathJoinSubstitution(
-        [FindPackageShare("openarm_bringup"), "config", "test_goal_publishers_config.yaml"]
+        [FindPackageShare("openarm_bringup"), "config",
+         "test_goal_publishers_config.yaml"]
     )
 
     return LaunchDescription(

--- a/openarm_description/launch/description.launch.py
+++ b/openarm_description/launch/description.launch.py
@@ -32,20 +32,21 @@ def generate_launch_description():
     default_model_path = pkg_share / "urdf/openarm.urdf.xacro"
 
     model_arg = launch.actions.DeclareLaunchArgument(
-                name="model",
-                default_value=str(default_model_path),
-                description="Absolute path to the robot's URDF file",
-            )
+        name="model",
+        default_value=str(default_model_path),
+        description="Absolute path to the robot's URDF file",
+    )
     side_arg = DeclareLaunchArgument(
         name="side", default_value="right",  # Use "left" to test left arm.
         description="Select arm side: 'left' or 'right'"
     )
     zero_pos_arg = DeclareLaunchArgument(
-        name="zero_pos", default_value="up",  # Use "arm" to test alternative configuration.
+        # Use "arm" to test alternative configuration.
+        name="zero_pos", default_value="up",
         description="Specify zero position: 'up' or 'arm'"
     )
     prefix_arg = DeclareLaunchArgument(
-        name="prefix", default_value="",  
+        name="prefix", default_value="",
         description="Prefix for link and joint names (e.g., left_, right_)"
     )
     can_device_arg = DeclareLaunchArgument(
@@ -54,7 +55,8 @@ def generate_launch_description():
     )
 
     use_sim_time = LaunchConfiguration("use_sim_time")
-    use_sim_time_launch_arg = DeclareLaunchArgument("use_sim_time", default_value="true")
+    use_sim_time_launch_arg = DeclareLaunchArgument(
+        "use_sim_time", default_value="true")
 
     robot_description_command = Command([
         "xacro ", LaunchConfiguration("model"),

--- a/openarm_description/launch/display.launch.py
+++ b/openarm_description/launch/display.launch.py
@@ -53,7 +53,8 @@ def generate_launch_description():
         package="joint_state_publisher",
         executable="joint_state_publisher",
         name="joint_state_publisher",
-        condition=launch.conditions.UnlessCondition(LaunchConfiguration("gui")),
+        condition=launch.conditions.UnlessCondition(
+            LaunchConfiguration("gui")),
         parameters=[
             {
                 "use_sim_time": use_sim_time,

--- a/openarm_description/launch/gazebo.launch.py
+++ b/openarm_description/launch/gazebo.launch.py
@@ -36,7 +36,8 @@ def generate_launch_description():
 
     # Make path to resources dir without last package_name fragment.
     path_to_share_dir_clipped = "".join(
-        get_package_share_directory(resources_package).rsplit("/" + resources_package, 1)
+        get_package_share_directory(resources_package).rsplit(
+            "/" + resources_package, 1)
     )
 
     # Gazebo hint for resources.
@@ -55,9 +56,11 @@ def generate_launch_description():
             os.environ["SDF_PATH"] = gz_sim_resource_path
 
     use_custom_world = LaunchConfiguration("use_custom_world")
-    use_custom_world_launch_arg = DeclareLaunchArgument("use_custom_world", default_value="true")
+    use_custom_world_launch_arg = DeclareLaunchArgument(
+        "use_custom_world", default_value="true")
     gazebo_world = LaunchConfiguration("gazebo_world")
-    gazebo_world_launch_arg = DeclareLaunchArgument("gazebo_world", default_value="empty.sdf")
+    gazebo_world_launch_arg = DeclareLaunchArgument(
+        "gazebo_world", default_value="empty.sdf")
 
     # prepare custom world
     world = os.getenv("GZ_SIM_WORLD", "empty")
@@ -100,7 +103,8 @@ def generate_launch_description():
     )
 
     use_sim_time = LaunchConfiguration("use_sim_time")
-    use_sim_time_launch_arg = DeclareLaunchArgument("use_sim_time", default_value="true")
+    use_sim_time_launch_arg = DeclareLaunchArgument(
+        "use_sim_time", default_value="true")
     use_rviz = LaunchConfiguration("use_rviz")
     use_rviz_arg = DeclareLaunchArgument("use_rviz", default_value="true")
 


### PR DESCRIPTION
We’ve added the autopep8 hook to our `.pre-commit-config.yaml` to enforce a consistent Python style.

To verify its behavior without touching every file at once, we’re applying it in-place to depth_camera.launch.py for now because the large number of impacted files there are.

The follow-up PR will run autopep8 accross the entire codebase once this initial change passes CI.

ref: https://github.com/hhatto/autopep8