### PR TITLE
Fix the RViz file name in the launch script

### DIFF
--- a/openarm_bringup/launch/openarm.launch.py
+++ b/openarm_bringup/launch/openarm.launch.py
@@ -175,7 +175,7 @@ def generate_launch_description():
     # RViz configuration
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare(description_package), "rviz",
-         "robot_description.rviz"]
+         "arm_only.rviz"]
     )
 
     rviz_node = Node(


### PR DESCRIPTION
`openarm_description` does not have `robot_description.rviz`, but it has `arm_only.rviz`.

https://github.com/enactic/openarm_description/tree/ab816fc11c62b19fa6206469f3c2a9b6dd6adc62/rviz