### PR TITLE
Add package dependencies for running openarm ros2 controller demo

### DIFF
--- a/openarm_bringup/package.xml
+++ b/openarm_bringup/package.xml
@@ -24,6 +24,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ros2_controllers</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
These dependencies were missing from the openarm_bringup package, which are necessary for running the example.