### PR TITLE
Update gripper_controller for new changes in ROS2 Jazzy

### DIFF
--- a/openarm_bimanual_moveit_config/config/ros2_controllers.yaml
+++ b/openarm_bimanual_moveit_config/config/ros2_controllers.yaml
@@ -24,10 +24,10 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     left_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     right_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
@@ -74,6 +74,7 @@ left_gripper_controller:
       - position
     state_interfaces:
       - position
+      - velocity
 
 right_gripper_controller:
   ros__parameters:
@@ -83,3 +84,4 @@ right_gripper_controller:
       - position
     state_interfaces:
       - position
+      - velocity

--- a/openarm_bringup/config/v10_controllers/openarm_v10_bimanual_controllers.yaml
+++ b/openarm_bringup/config/v10_controllers/openarm_v10_bimanual_controllers.yaml
@@ -30,7 +30,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     left_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     right_forward_position_controller:
       type: forward_command_controller/ForwardCommandController
@@ -42,7 +42,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     right_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
 
 left_forward_position_controller:
@@ -108,6 +108,7 @@ left_gripper_controller:
       - position
     state_interfaces:
       - position
+      - velocity
 
 
 right_forward_position_controller:
@@ -173,3 +174,4 @@ right_gripper_controller:
       - position
     state_interfaces:
       - position
+      - velocity

--- a/openarm_bringup/config/v10_controllers/openarm_v10_controllers.yaml
+++ b/openarm_bringup/config/v10_controllers/openarm_v10_controllers.yaml
@@ -30,7 +30,7 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
 
     gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
 forward_position_controller:
   ros__parameters:
@@ -97,3 +97,4 @@ gripper_controller:
       - position
     state_interfaces:
       - position
+      - velocity


### PR DESCRIPTION
Addresses https://github.com/enactic/openarm_ros2/issues/59.

Changes necessary to support ROS2 Jazzy. I believe these are not backwards-compatible, so it's probably best to make a separate branch for this change until the repo is ready to upgrade to Jazzy.

`position_controllers` -> `parallel_gripper_action_controller` (+ add velocity state to gripper controllers): https://control.ros.org/jazzy/doc/ros2_controllers/gripper_controllers/doc/userdoc.html, https://github.com/ros-controls/ros2_controllers/pull/1652