### PR TITLE
fix(openarm_hardware): modify pd-gains of controllers

### DIFF
--- a/openarm_hardware/include/openarm_hardware/v10_simple_hardware.hpp
+++ b/openarm_hardware/include/openarm_hardware/v10_simple_hardware.hpp
@@ -102,9 +102,8 @@ class OpenArm_v10HW : public hardware_interface::SystemInterface {
 
   // Default gains
   const std::vector<double> DEFAULT_KP = {150.0, 150.0, 150.0, 120.0,
-                                          10.0, 10.0, 10.0};
-  const std::vector<double> DEFAULT_KD = {2.75, 2.5, 2.0, 2.0,
-                                          0.7,  0.6, 0.5};
+                                          10.0,  10.0,  10.0};
+  const std::vector<double> DEFAULT_KD = {2.75, 2.5, 2.0, 2.0, 0.7, 0.6, 0.5};
 
   const double GRIPPER_JOINT_0_POSITION = 0.044;
   const double GRIPPER_JOINT_1_POSITION = 0.0;


### PR DESCRIPTION
ignored the copilot comments as it's nonsense :)

@tokirobot @euyniy 
As I mentioned in  https://github.com/enactic/openarm_ros2/issues/68 , I used the gains from openarm_teleop and fixes the conservatism in the controller. As discussed in the issue, this greatly enhances the tracking performance of the controller. I tested on real hw with this configuration multiple times and have not encountered any problem. 

Although I think these PD gains should be loadable from yaml file by rosparam, but such changes might be bit off the scope so I didnt do that. 

Fix https://github.com/enactic/openarm_ros2/issues/68

## test on real HW (see the original issue for the test code and the setting)
Before this PR (joint 1)
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/4890d407-0781-4c54-ae48-baee7eca59f2" />

After this PR (joint 1)
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/a46d331f-2a17-4745-bebf-09f80bc91c1f" />

Before This PR (joint 4)
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/c07cf7b8-f91e-4c3d-9fce-6971b0ea40dd" />

After this PR (joint 4)
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/625ac5b5-df7d-4483-9d19-71109245fe20" />
