### PR TITLE
feat: openarm_can as a ros package

### DIFF
--- a/openarm.repos
+++ b/openarm.repos
@@ -1,0 +1,19 @@
+# Copyright 2025 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repositories:
+  openarm_can:
+    type: git
+    url: https://github.com/enactic/openarm_can.git
+    version: main

--- a/openarm_hardware/CMakeLists.txt
+++ b/openarm_hardware/CMakeLists.txt
@@ -70,6 +70,7 @@ ament_export_libraries(
 )
 ament_export_dependencies(
   hardware_interface
+  openarm_can
   pluginlib
   rclcpp
 )

--- a/openarm_hardware/package.xml
+++ b/openarm_hardware/package.xml
@@ -26,6 +26,7 @@
 
   <depend>rclcpp</depend>
   <depend>hardware_interface</depend>
+  <depend>openarm_can</depend>
   <depend>pluginlib</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Related to https://github.com/enactic/openarm_can/pull/74 and https://github.com/enactic/openarm/pull/359. The edit makes it possible to include `openarm_can` as a ros2 workspace package and built together with colcon. It still possible to install openarm_can systemwide.